### PR TITLE
feat(auth): adicionar página de reset de senha

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -106,7 +106,7 @@ lnkForgot?.addEventListener("click", async (ev) => {
   try {
     await connectSupabase();
     const { error: e } = await sb.auth.resetPasswordForEmail(email, {
-      redirectTo: `${window.location.origin}/auth/index.html`,
+      redirectTo: `${window.location.origin}/auth/reset.html`,
     });
     if (e) return error(t(e.message));
     ok("Enviamos um link para redefinição. Abra o e-mail mais recente.");
@@ -143,3 +143,4 @@ lnkResend?.addEventListener("click", async (ev) => {
     if (ev.key === "Enter") btnIn?.click();
   })
 );
+

--- a/auth/reset.html
+++ b/auth/reset.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="pt-BR">
+  <meta charset="utf-8">
+  <title>Reset de senha — Bidly</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <body style="font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial; padding:24px">
+    <h1>Reset de senha</h1>
+    <p>Placeholder. Esta é a rota dedicada de redefinição.</p>
+  </body>
+</html>


### PR DESCRIPTION
- Criada a página /auth/reset.html (placeholder inicial)
- Ajustado o redirect do e-mail de recuperação para a nova página
- Estrutura preparada para futura lógica de reset
